### PR TITLE
dependabot: Enable npm package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
-# Set update schedule for GitHub Actions
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
       interval: "weekly"


### PR DESCRIPTION
References:
* https://github.blog/changelog/2022-09-07-dependabot-unlocks-transitive-dependencies-for-npm-projects/
* https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/